### PR TITLE
add use_proxy_stage flag to ApiGateway, bump version to 1.1.0 & updat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ from async_ip_rotator import ApiGateway
 
 async def main():
     # Create and use gateway with async context manager
-    async with ApiGateway("https://site.com") as gateway:
+    # Disable the default /ProxyStage path if needed to avoid changing signature for certain private endpoints
+    async with ApiGateway("https://site.com", use_proxy_stage=False) as gateway:
         # Create async client with gateway
         async with httpx.AsyncClient(transport=gateway) as client:
             # Send request (IP will be randomized)
@@ -59,6 +60,7 @@ The ApiGateway class can be created with the following optional parameters:
 | access_key_id | AWS Access Key ID (will override env variables) | False | *Relies on env variables* |
 | access_key_secret | AWS Access Key Secret (will override env variables) | False | *Relies on env variables* |
 | verbose | Include status and error messages | False | True |
+| use_proxy_stage | Include '/ProxyStage' prefix in gateway URL (set False when not required) | False | True |
 
 ```python
 from async_ip_rotator import ApiGateway, EXTRA_REGIONS, ALL_REGIONS

--- a/async_ip_rotator/ip_rotator.py
+++ b/async_ip_rotator/ip_rotator.py
@@ -30,7 +30,17 @@ ALL_REGIONS = EXTRA_REGIONS + [
 # Inherits from httpx.AsyncBaseTransport so that we can edit each request before sending
 class ApiGateway(httpx.AsyncBaseTransport):
 
-    def __init__(self, site, regions=DEFAULT_REGIONS, access_key_id=None, access_key_secret=None, verbose=True, **kwargs):
+    def __init__(
+        self,
+        site: str,
+        regions: list[str] = DEFAULT_REGIONS,
+        access_key_id: str | None = None,
+        access_key_secret: str | None = None,
+        verbose: bool = True,
+        *,
+        use_proxy_stage: bool = True,
+        **kwargs,
+    ) -> None:
         super().__init__(**kwargs)
         # Set simple params from constructor
         if site.endswith("/"):
@@ -42,7 +52,8 @@ class ApiGateway(httpx.AsyncBaseTransport):
         self.api_name = site + " - IP Rotate API"
         self.regions = regions
         self.verbose = verbose
-        self.endpoints = []
+        self.endpoints: list[str] = []
+        self.use_proxy_stage: bool = use_proxy_stage
         self._client = httpx.AsyncClient()
 
     # Enter and exit blocks to allow "with" clause
@@ -69,8 +80,9 @@ class ApiGateway(httpx.AsyncBaseTransport):
         if path.startswith("/"):
             path = path[1:]
             
-        # Create new URL with our endpoint
-        new_url = f"https://{endpoint}/ProxyStage/{path}"
+        # Build base URL with or without the /ProxyStage segment depending on flag
+        stage_segment = "/ProxyStage" if self.use_proxy_stage else ""
+        new_url = f"https://{endpoint}{stage_segment}/{path}" if path else f"https://{endpoint}{stage_segment}"
         if request.url.query:
             new_url += f"?{request.url.query.decode() if isinstance(request.url.query, bytes) else request.url.query}"
         

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ README = (location / "README.md").read_text()
 
 setup(
     name="async-ip-rotator",
-    version="1.0.0",
+    version="1.1.0",
     description="Async IP rotation using AWS API Gateway with httpx support",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ location = pathlib.Path(__file__).parent
 README = (location / "README.md").read_text()
 
 setup(
-    name="async-ip-rotator",
-    version="1.1.0",
+    name="async-aws-ip-rotator",
+    version="1.0.2",
     description="Async IP rotation using AWS API Gateway with httpx support",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
…e README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to control inclusion of the `/ProxyStage` path prefix in the gateway URL for the API Gateway class.

* **Documentation**
  * Updated the README to document the new parameter and provide an example of its usage.

* **Chores**
  * Updated package name to "async-aws-ip-rotator" and bumped version to 1.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->